### PR TITLE
feat(logging): structured JSON logging with slog and OTel trace corre…

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,7 +3,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -15,10 +15,11 @@ import (
 	"github.com/joho/godotenv"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
-	// importa o router do projeto
+	"github.com/Ulpio/vergo/internal/http/middleware"
 	"github.com/Ulpio/vergo/internal/http/router"
 	"github.com/Ulpio/vergo/internal/pkg/config"
 	"github.com/Ulpio/vergo/internal/pkg/db"
+	"github.com/Ulpio/vergo/internal/pkg/logging"
 	"github.com/Ulpio/vergo/internal/pkg/telemetry"
 )
 
@@ -29,45 +30,51 @@ func init() {
 }
 
 func main() {
-	// Carrega configurações
 	cfg := config.Load()
 	port := cfg.AppPort
 	env := cfg.AppEnv
 	version := cfg.AppVersion
 
-	// Inicializa OpenTelemetry (TracerProvider + MeterProvider)
+	// Initialize structured logger
+	logger := logging.New(env)
+	slog.SetDefault(logger)
+
+	// Initialize OpenTelemetry (TracerProvider + MeterProvider)
 	ctx := context.Background()
 	shutdownTelemetry, err := telemetry.Init(ctx, telemetry.Config{
 		ServiceName:    "vergo",
 		ServiceVersion: version,
 	})
 	if err != nil {
-		log.Fatalf("telemetry init: %v", err)
+		slog.Error("telemetry init failed", "error", err)
+		os.Exit(1)
 	}
 	defer func() {
 		if err := shutdownTelemetry(context.Background()); err != nil {
-			log.Printf("telemetry shutdown: %v", err)
+			slog.Error("telemetry shutdown failed", "error", err)
 		}
 	}()
 
-	// Conecta ao banco de dados
-	log.Println("Conectando ao banco de dados...")
+	// Connect to database
+	slog.Info("connecting to database")
 	database, err := db.Open(cfg)
 	if err != nil {
-		log.Fatalf("Erro ao conectar ao banco: %v", err)
+		slog.Error("database connection failed", "error", err)
+		os.Exit(1)
 	}
 	defer database.Close()
 
-	// Testa a conexão
 	if err := database.Ping(); err != nil {
-		log.Fatalf("Erro ao fazer ping no banco: %v", err)
+		slog.Error("database ping failed", "error", err)
+		os.Exit(1)
 	}
-	log.Println("Conexão com o banco estabelecida")
+	slog.Info("database connection established")
 
-	// Executa migrations
-	log.Println("🚀 Executando migrations...")
+	// Run migrations
+	slog.Info("running migrations")
 	if err := db.RunMigrations(database); err != nil {
-		log.Fatalf("Erro ao executar migrations: %v", err)
+		slog.Error("migrations failed", "error", err)
+		os.Exit(1)
 	}
 
 	if env != "dev" {
@@ -75,8 +82,9 @@ func main() {
 	}
 
 	r := gin.New()
-	r.Use(gin.Recovery())
+	r.Use(middleware.Recover())
 	r.Use(otelgin.Middleware("vergo"))
+	r.Use(middleware.Logging())
 
 	// Health endpoints
 	startedAt := time.Now()
@@ -92,19 +100,17 @@ func main() {
 		c.Status(http.StatusOK)
 	})
 
-	// Grupo da API v1
+	// API v1
 	api := r.Group("/v1")
 	{
-		// rota simples de ping
 		api.GET("/_ping", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"pong": true})
 		})
 
-		// registra todos os endpoints stubs
 		router.Register(api)
 	}
 
-	// servidor HTTP com shutdown gracioso
+	// HTTP server with graceful shutdown
 	srv := &http.Server{
 		Addr:         ":" + strconv.Itoa(port),
 		Handler:      r,
@@ -114,37 +120,23 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("vergo listening on :%d (env=%s, version=%s)", port, env, version)
+		slog.Info("server started", "port", port, "env", env, "version", version)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server error: %v", err)
+			slog.Error("server error", "error", err)
+			os.Exit(1)
 		}
 	}()
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
-	log.Println("shutting down...")
+	slog.Info("shutting down")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("forced to shutdown: %v", err)
+		slog.Error("forced shutdown", "error", err)
+		os.Exit(1)
 	}
-	log.Println("bye!")
-}
-
-func getEnv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
-func getEnvInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			return i
-		}
-	}
-	return def
+	slog.Info("server stopped")
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/joho/godotenv v1.5.1
+	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/crypto v0.47.0
 )
 
@@ -33,7 +34,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 )
 
 require (

--- a/internal/http/handlers/storage.go
+++ b/internal/http/handlers/storage.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -188,9 +189,9 @@ func (h *StorageHandler) DeleteFile(c *gin.Context) {
 		return
 	}
 
-	// Deleta no S3 (best-effort; se quiser ser estrito, trate o erro)
+	// Deleta no S3 (best-effort)
 	if err := h.s3.DeleteObject(c.Request.Context(), f.Bucket, f.ObjectKey); err != nil {
-		// log.Printf("s3 delete failed: %v", err)
+		slog.ErrorContext(c.Request.Context(), "s3 delete failed", "error", err)
 	}
 
 	// Remove metadados

--- a/internal/http/middleware/logging.go
+++ b/internal/http/middleware/logging.go
@@ -1,1 +1,43 @@
 package middleware
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Logging returns a middleware that logs each HTTP request with structured
+// fields: method, path, status, latency, and client_ip.
+// Log level is Info for 2xx/3xx, Warn for 4xx, Error for 5xx.
+// trace_id and span_id are injected automatically by the otelHandler via context.
+func Logging() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		method := c.Request.Method
+
+		c.Next()
+
+		status := c.Writer.Status()
+		latency := time.Since(start)
+		ctx := c.Request.Context()
+
+		attrs := []slog.Attr{
+			slog.String("method", method),
+			slog.String("path", path),
+			slog.Int("status", status),
+			slog.Duration("latency", latency),
+			slog.String("client_ip", c.ClientIP()),
+		}
+
+		level := slog.LevelInfo
+		if status >= 500 {
+			level = slog.LevelError
+		} else if status >= 400 {
+			level = slog.LevelWarn
+		}
+
+		slog.LogAttrs(ctx, level, "http request", attrs...)
+	}
+}

--- a/internal/http/middleware/logging_test.go
+++ b/internal/http/middleware/logging_test.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupLoggingTest(handler gin.HandlerFunc) (*httptest.ResponseRecorder, *bytes.Buffer) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	r := gin.New()
+	r.Use(Logging())
+	r.GET("/test", handler)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+
+	return w, &buf
+}
+
+func TestLogging_OK(t *testing.T) {
+	w, buf := setupLoggingTest(func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON log: %v\nraw: %s", err, buf.String())
+	}
+
+	if got := entry["method"]; got != "GET" {
+		t.Errorf("method = %v, want GET", got)
+	}
+	if got := entry["path"]; got != "/test" {
+		t.Errorf("path = %v, want /test", got)
+	}
+	if got, ok := entry["status"].(float64); !ok || int(got) != 200 {
+		t.Errorf("status = %v, want 200", entry["status"])
+	}
+	if _, ok := entry["latency"]; !ok {
+		t.Error("latency field missing")
+	}
+	if got := entry["level"]; got != "INFO" {
+		t.Errorf("level = %v, want INFO", got)
+	}
+}
+
+func TestLogging_NotFound(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	r := gin.New()
+	r.Use(Logging())
+	// No route registered — Gin returns 404
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON log: %v\nraw: %s", err, buf.String())
+	}
+
+	if got := entry["level"]; got != "WARN" {
+		t.Errorf("level = %v, want WARN for 404", got)
+	}
+}
+
+func TestLogging_ServerError(t *testing.T) {
+	_, buf := setupLoggingTest(func(c *gin.Context) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "fail"})
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON log: %v\nraw: %s", err, buf.String())
+	}
+
+	if got := entry["level"]; got != "ERROR" {
+		t.Errorf("level = %v, want ERROR for 500", got)
+	}
+}

--- a/internal/http/middleware/recover.go
+++ b/internal/http/middleware/recover.go
@@ -1,1 +1,36 @@
 package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Recover returns a middleware that recovers from panics, logs a structured
+// error with stack trace, and returns a generic 500 JSON response.
+// It replaces gin.Recovery() with structured logging via slog.
+func Recover() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				stack := string(debug.Stack())
+				ctx := c.Request.Context()
+
+				slog.ErrorContext(ctx, "panic recovered",
+					slog.String("error", fmt.Sprint(err)),
+					slog.String("method", c.Request.Method),
+					slog.String("path", c.Request.URL.Path),
+					slog.String("stack", stack),
+				)
+
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+					"error": "internal_server_error",
+				})
+			}
+		}()
+		c.Next()
+	}
+}

--- a/internal/http/middleware/recover_test.go
+++ b/internal/http/middleware/recover_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRecover_NoPanic(t *testing.T) {
+	r := gin.New()
+	r.Use(Recover())
+	r.GET("/ok", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestRecover_WithPanic(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	r := gin.New()
+	r.Use(Recover())
+	r.GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	r.ServeHTTP(w, req)
+
+	// Verify 500 response
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+
+	// Verify response body
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if got := body["error"]; got != "internal_server_error" {
+		t.Errorf("error = %v, want internal_server_error", got)
+	}
+
+	// Verify structured log
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON log: %v\nraw: %s", err, buf.String())
+	}
+	if got := entry["msg"]; got != "panic recovered" {
+		t.Errorf("msg = %v, want panic recovered", got)
+	}
+	if got, ok := entry["error"].(string); !ok || got != "boom" {
+		t.Errorf("error = %v, want boom", entry["error"])
+	}
+	if got, ok := entry["stack"].(string); !ok || got == "" {
+		t.Error("stack trace missing or empty")
+	}
+}
+
+func TestRecover_PanicDoesNotLeak(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)))
+
+	r := gin.New()
+	r.Use(Recover())
+	r.GET("/secret-panic", func(c *gin.Context) {
+		panic("sensitive internal error details")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/secret-panic", nil)
+	r.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "sensitive internal error details") {
+		t.Error("panic message leaked in response body")
+	}
+}

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
@@ -49,9 +49,9 @@ func RunMigrations(db *sql.DB) error {
 	}
 
 	if err == migrate.ErrNoChange {
-		log.Println("✅ migrations já estão atualizadas")
+		slog.Info("migrations up to date")
 	} else {
-		log.Println("✅ migrations aplicadas com sucesso")
+		slog.Info("migrations applied successfully")
 	}
 	return nil
 }

--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -1,0 +1,54 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// New creates a *slog.Logger wrapped with an otelHandler that automatically
+// injects trace_id and span_id from the OpenTelemetry span context.
+// In dev mode it uses a human-readable text handler; otherwise JSON.
+func New(env string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+
+	var base slog.Handler
+	if env == "dev" {
+		base = slog.NewTextHandler(os.Stdout, opts)
+	} else {
+		base = slog.NewJSONHandler(os.Stdout, opts)
+	}
+
+	return slog.New(&otelHandler{inner: base})
+}
+
+// otelHandler wraps any slog.Handler, injecting trace_id and span_id
+// extracted from the OpenTelemetry span in the context.
+type otelHandler struct {
+	inner slog.Handler
+}
+
+func (h *otelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *otelHandler) Handle(ctx context.Context, r slog.Record) error {
+	sc := trace.SpanFromContext(ctx).SpanContext()
+	if sc.HasTraceID() {
+		r.AddAttrs(slog.String("trace_id", sc.TraceID().String()))
+	}
+	if sc.HasSpanID() {
+		r.AddAttrs(slog.String("span_id", sc.SpanID().String()))
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *otelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &otelHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *otelHandler) WithGroup(name string) slog.Handler {
+	return &otelHandler{inner: h.inner.WithGroup(name)}
+}

--- a/internal/pkg/logging/logging_test.go
+++ b/internal/pkg/logging/logging_test.go
@@ -1,0 +1,80 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestOtelHandler_WithSpanContext(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, nil)
+	logger := slog.New(&otelHandler{inner: base})
+
+	traceID, _ := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	spanID, _ := trace.SpanIDFromHex("b7ad6b7169203331")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	logger.InfoContext(ctx, "test message")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if got := entry["trace_id"]; got != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("trace_id = %v, want 0af7651916cd43dd8448eb211c80319c", got)
+	}
+	if got := entry["span_id"]; got != "b7ad6b7169203331" {
+		t.Errorf("span_id = %v, want b7ad6b7169203331", got)
+	}
+	if got := entry["msg"]; got != "test message" {
+		t.Errorf("msg = %v, want test message", got)
+	}
+}
+
+func TestOtelHandler_WithoutSpan(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, nil)
+	logger := slog.New(&otelHandler{inner: base})
+
+	logger.InfoContext(context.Background(), "no span")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if _, ok := entry["trace_id"]; ok {
+		t.Error("trace_id should not be present without span context")
+	}
+	if _, ok := entry["span_id"]; ok {
+		t.Error("span_id should not be present without span context")
+	}
+}
+
+func TestNew_DevMode(t *testing.T) {
+	logger := New("dev")
+	if logger == nil {
+		t.Fatal("New(dev) returned nil")
+	}
+	// Verify it can log without panic
+	logger.Info("dev mode test")
+}
+
+func TestNew_ProdMode(t *testing.T) {
+	logger := New("production")
+	if logger == nil {
+		t.Fatal("New(production) returned nil")
+	}
+	logger.Info("prod mode test")
+}


### PR DESCRIPTION
Replace all log.Println/log.Fatalf calls with log/slog for structured JSON output. Add custom otelHandler that automatically injects trace_id and span_id from OpenTelemetry span context into every log line.

- Add internal/pkg/logging package with otelHandler wrapper
- Implement Logging middleware (method, path, status, latency, client_ip)
- Implement Recover middleware replacing gin.Recovery() with structured stack traces
- Reorder middlewares: Recover → otelgin → Logging
- Zero remaining log.Println/fmt.Println usage
- Add unit tests for otelHandler, Logging, and Recover middlewares

Closes #29

## O que foi feito

### Novo pacote `internal/pkg/logging`
- `otelHandler` — wrapper de `slog.Handler` que extrai `trace_id` e `span_id` do OpenTelemetry span context e injeta automaticamente em cada log line
- `New(env)` — cria logger com JSON handler (prod) ou text handler (dev)

### Middlewares preenchidos
- **`middleware.Logging()`** — loga cada request com method, path, status, latency e client_ip. Level escala: Info (2xx/3xx), Warn (4xx), Error (5xx)
- **`middleware.Recover()`** — substitui `gin.Recovery()` com stack trace estruturado via slog. Retorna 500 genérico sem vazar detalhes internos

### Refactor em `main.go`
- Inicializa slog como default logger antes de qualquer operação
- Reordena middlewares: Recover → otelgin → Logging (garante que o span existe quando o log é emitido)
- Todas as 12 chamadas `log.Println`/`log.Fatalf` substituídas por `slog.Info`/`slog.Error` + `os.Exit(1)`
- Removidas funções mortas `getEnv()` e `getEnvInt()` (duplicatas de config.go)

### Outros arquivos
- `db.go` — 2x `log.Println` → `slog.Info`
- `storage.go` — log comentado ativado com `slog.ErrorContext` para falhas de S3 delete

### Testes (10 novos)
- `logging_test.go` — otelHandler com/sem span context, modos dev/prod
- `logging_test.go` (middleware) — respostas 200, 404, 500 com levels corretos
- `recover_test.go` — sem panic, com panic, e validação de que detalhes internos não vazam no response body

## Como testar

```bash
# Testes unitários (10 testes, 0 falhas)
go test ./internal/pkg/logging/... ./internal/http/middleware/... -v

# Build + vet
go build ./... && go vet ./...

# Verificar zero log.Println restante
grep -r 'log\.Print\|fmt\.Print' internal/ cmd/ --include='*.go'
# (sem resultados)

# Smoke test (requer docker-compose up)
make dev
curl -s localhost:8080/healthz | jq
# Log JSON no stdout com trace_id e span_id
```
## Checklist
- [x] Testes passando (`go test ./...`)
- [x] Atualizei documentação/README se necessário
- [x] PR segue padrão de commits
