### PR TITLE
feat(security): in-memory rate limiting middleware

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Ulpio/vergo/internal/pkg/config"
 	"github.com/Ulpio/vergo/internal/pkg/db"
 	"github.com/Ulpio/vergo/internal/pkg/logging"
+	"github.com/Ulpio/vergo/internal/pkg/ratelimit"
 	"github.com/Ulpio/vergo/internal/pkg/telemetry"
 )
 
@@ -81,9 +82,14 @@ func main() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
+	// Rate limiter (in-memory token bucket)
+	limiter := ratelimit.New(float64(cfg.RateLimitRPS), cfg.RateLimitBurst)
+	defer limiter.Stop()
+
 	r := gin.New()
 	r.Use(middleware.Recover())
 	r.Use(otelgin.Middleware("vergo"))
+	r.Use(middleware.RateLimit(limiter))
 	r.Use(middleware.Logging())
 
 	// Health endpoints

--- a/internal/http/middleware/ratelimit.go
+++ b/internal/http/middleware/ratelimit.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Ulpio/vergo/internal/pkg/ratelimit"
+)
+
+// RateLimit returns a middleware that limits requests using a token bucket
+// algorithm. It applies rate limiting by client IP, and additionally by
+// tenant (org_id) if available in the context.
+//
+// Response headers:
+//   - X-RateLimit-Limit:     max requests (burst)
+//   - X-RateLimit-Remaining: tokens left
+//   - Retry-After:           seconds to wait (only on 429)
+func RateLimit(limiter *ratelimit.Limiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := rateLimitKey(c)
+
+		if !limiter.Allow(key) {
+			remaining := limiter.Remaining(key)
+			c.Header("X-RateLimit-Limit", strconv.Itoa(limiter.Burst()))
+			c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			c.Header("Retry-After", "1")
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": "rate_limit_exceeded",
+			})
+			return
+		}
+
+		remaining := limiter.Remaining(key)
+		c.Header("X-RateLimit-Limit", strconv.Itoa(limiter.Burst()))
+		c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+
+		c.Next()
+	}
+}
+
+// rateLimitKey builds the rate limit key. If an org_id is present in the
+// context (set by Tenant middleware), it uses "tenant:<org_id>".
+// Otherwise, it falls back to "ip:<client_ip>".
+func rateLimitKey(c *gin.Context) string {
+	if orgID, ok := OrgID(c); ok {
+		return "tenant:" + orgID
+	}
+	return "ip:" + c.ClientIP()
+}

--- a/internal/http/middleware/ratelimit_test.go
+++ b/internal/http/middleware/ratelimit_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Ulpio/vergo/internal/pkg/ratelimit"
+)
+
+func TestRateLimit_AllowsWithinBurst(t *testing.T) {
+	limiter := ratelimit.New(10, 3)
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(RateLimit(limiter))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	for i := range 3 {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i+1, w.Code)
+		}
+		if w.Header().Get("X-RateLimit-Limit") != "3" {
+			t.Errorf("X-RateLimit-Limit = %s, want 3", w.Header().Get("X-RateLimit-Limit"))
+		}
+	}
+}
+
+func TestRateLimit_RejectsOverBurst(t *testing.T) {
+	limiter := ratelimit.New(10, 2)
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(RateLimit(limiter))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// Exhaust burst
+	for range 2 {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r.ServeHTTP(w, req)
+	}
+
+	// 3rd should be 429
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", w.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["error"] != "rate_limit_exceeded" {
+		t.Errorf("error = %v, want rate_limit_exceeded", body["error"])
+	}
+	if w.Header().Get("Retry-After") != "1" {
+		t.Errorf("Retry-After = %s, want 1", w.Header().Get("Retry-After"))
+	}
+}
+
+func TestRateLimit_HeadersPresent(t *testing.T) {
+	limiter := ratelimit.New(10, 5)
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(RateLimit(limiter))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Header().Get("X-RateLimit-Limit") == "" {
+		t.Error("X-RateLimit-Limit header missing")
+	}
+	if w.Header().Get("X-RateLimit-Remaining") == "" {
+		t.Error("X-RateLimit-Remaining header missing")
+	}
+}
+
+func TestRateLimit_UsesTenantKeyWhenAvailable(t *testing.T) {
+	limiter := ratelimit.New(10, 1)
+	defer limiter.Stop()
+
+	r := gin.New()
+	// Simulate tenant middleware by setting org_id
+	r.Use(func(c *gin.Context) {
+		c.Set("org_id", "org-123")
+		c.Next()
+	})
+	r.Use(RateLimit(limiter))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// First request allowed (tenant:org-123 bucket)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	// Second request rejected (same tenant bucket)
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (same tenant)", w2.Code)
+	}
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	// Storage policy (opcional)
 	StorageAllowedTypes []string
 	StorageMaxMB        int
+
+	// Rate limiting
+	RateLimitRPS   int // requests per second per key
+	RateLimitBurst int // max burst size
 }
 
 func getenv(key, def string) string {
@@ -110,5 +114,9 @@ func Load() Config {
 		// Storage policy
 		StorageAllowedTypes: splitCSV(getenv("STORAGE_ALLOWED_TYPES", "")),
 		StorageMaxMB:        getint("STORAGE_MAX_MB", 25),
+
+		// Rate limiting
+		RateLimitRPS:   getint("RATE_LIMIT_RPS", 20),
+		RateLimitBurst: getint("RATE_LIMIT_BURST", 40),
 	}
 }

--- a/internal/pkg/ratelimit/limiter.go
+++ b/internal/pkg/ratelimit/limiter.go
@@ -1,0 +1,116 @@
+// Package ratelimit provides an in-memory token bucket rate limiter.
+// Each key (IP or tenant) gets an independent bucket that refills at a
+// configured rate. Stale buckets are cleaned up periodically.
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter is a thread-safe token bucket rate limiter keyed by string.
+type Limiter struct {
+	rate     float64       // tokens added per second
+	burst    int           // max tokens (bucket capacity)
+	mu       sync.Mutex
+	buckets  map[string]*bucket
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+type bucket struct {
+	tokens   float64
+	lastSeen time.Time
+}
+
+// New creates a Limiter that allows `rate` requests/second with a burst of `burst`.
+// It starts a background goroutine to evict stale entries every minute.
+func New(rate float64, burst int) *Limiter {
+	l := &Limiter{
+		rate:    rate,
+		burst:   burst,
+		buckets: make(map[string]*bucket),
+		stopCh:  make(chan struct{}),
+	}
+	go l.cleanup()
+	return l
+}
+
+// Allow reports whether a request for the given key is allowed.
+// It consumes one token if available.
+func (l *Limiter) Allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: float64(l.burst), lastSeen: now}
+		l.buckets[key] = b
+	}
+
+	// Refill tokens based on elapsed time
+	elapsed := now.Sub(b.lastSeen).Seconds()
+	b.tokens += elapsed * l.rate
+	if b.tokens > float64(l.burst) {
+		b.tokens = float64(l.burst)
+	}
+	b.lastSeen = now
+
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// Remaining returns the current token count for a key (for headers).
+func (l *Limiter) Remaining(key string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b, ok := l.buckets[key]
+	if !ok {
+		return l.burst
+	}
+
+	// Calculate current tokens without consuming
+	elapsed := time.Since(b.lastSeen).Seconds()
+	tokens := b.tokens + elapsed*l.rate
+	if tokens > float64(l.burst) {
+		tokens = float64(l.burst)
+	}
+	return int(tokens)
+}
+
+// Burst returns the max bucket capacity.
+func (l *Limiter) Burst() int {
+	return l.burst
+}
+
+// Stop halts the background cleanup goroutine.
+func (l *Limiter) Stop() {
+	l.stopOnce.Do(func() { close(l.stopCh) })
+}
+
+// cleanup evicts buckets not seen in the last 5 minutes.
+func (l *Limiter) cleanup() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-ticker.C:
+			l.mu.Lock()
+			cutoff := time.Now().Add(-5 * time.Minute)
+			for k, b := range l.buckets {
+				if b.lastSeen.Before(cutoff) {
+					delete(l.buckets, k)
+				}
+			}
+			l.mu.Unlock()
+		}
+	}
+}

--- a/internal/pkg/ratelimit/limiter_test.go
+++ b/internal/pkg/ratelimit/limiter_test.go
@@ -1,0 +1,88 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAllow_BurstThenReject(t *testing.T) {
+	l := New(10, 3) // 10/s, burst 3
+	defer l.Stop()
+
+	// Should allow burst of 3
+	for i := range 3 {
+		if !l.Allow("key1") {
+			t.Fatalf("request %d should be allowed within burst", i+1)
+		}
+	}
+
+	// 4th should be rejected
+	if l.Allow("key1") {
+		t.Fatal("request 4 should be rejected after burst exhausted")
+	}
+}
+
+func TestAllow_RefillAfterWait(t *testing.T) {
+	l := New(100, 1) // 100/s, burst 1 — refills fast
+	defer l.Stop()
+
+	if !l.Allow("key1") {
+		t.Fatal("first request should be allowed")
+	}
+	if l.Allow("key1") {
+		t.Fatal("second request should be rejected immediately")
+	}
+
+	// Wait for refill (at 100/s, 1 token refills in 10ms)
+	time.Sleep(15 * time.Millisecond)
+
+	if !l.Allow("key1") {
+		t.Fatal("request should be allowed after refill")
+	}
+}
+
+func TestAllow_IndependentKeys(t *testing.T) {
+	l := New(10, 1) // burst 1
+	defer l.Stop()
+
+	if !l.Allow("ip1") {
+		t.Fatal("ip1 first request should be allowed")
+	}
+	if !l.Allow("ip2") {
+		t.Fatal("ip2 first request should be allowed (independent)")
+	}
+
+	// ip1 exhausted, ip2 exhausted
+	if l.Allow("ip1") {
+		t.Fatal("ip1 should be rejected")
+	}
+	if l.Allow("ip2") {
+		t.Fatal("ip2 should be rejected")
+	}
+}
+
+func TestRemaining(t *testing.T) {
+	l := New(10, 5)
+	defer l.Stop()
+
+	if got := l.Remaining("new-key"); got != 5 {
+		t.Fatalf("remaining = %d, want 5 for new key", got)
+	}
+
+	l.Allow("new-key") // consume 1
+	l.Allow("new-key") // consume 2
+
+	got := l.Remaining("new-key")
+	if got < 2 || got > 3 {
+		t.Fatalf("remaining = %d, want ~3 after consuming 2 from burst 5", got)
+	}
+}
+
+func TestBurst(t *testing.T) {
+	l := New(10, 42)
+	defer l.Stop()
+
+	if l.Burst() != 42 {
+		t.Fatalf("burst = %d, want 42", l.Burst())
+	}
+}


### PR DESCRIPTION
## Summary
- Token bucket rate limiter keyed by tenant (`org_id`) or client IP
- Configurable via `RATE_LIMIT_RPS` (default 20) and `RATE_LIMIT_BURST` (default 40) env vars
- Response headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After` (on 429)
- Background goroutine evicts stale buckets every minute

## O que foi feito
- `internal/pkg/ratelimit/limiter.go` — token bucket implementation with cleanup
- `internal/http/middleware/ratelimit.go` — Gin middleware with tenant/IP key selection
- `internal/pkg/config/config.go` — new `RateLimitRPS` and `RateLimitBurst` fields
- `cmd/api/main.go` — register middleware in chain: Recover → otelgin → RateLimit → Logging

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — 15 tests pass (5 new for ratelimit + 4 middleware)
- [x] `go vet ./...` clean
- [ ] Manual: burst requests to confirm 429 + headers

Closes #39