### PR TITLE
feat(audit): metadata diff (before/after) and expanded coverage

### DIFF
--- a/db/migrations/0007_audit_metadata.up.sql
+++ b/db/migrations/0007_audit_metadata.up.sql
@@ -1,0 +1,5 @@
+-- Add metadata column for before/after diff tracking
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}';
+
+-- Index for querying metadata fields
+CREATE INDEX IF NOT EXISTS idx_audit_metadata ON audit_logs USING gin(metadata);

--- a/internal/domain/audit/model.go
+++ b/internal/domain/audit/model.go
@@ -1,6 +1,9 @@
 package audit
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Event struct {
 	OrgID     string    `json:"org_id"`
@@ -9,6 +12,13 @@ type Event struct {
 	Entity    string    `json:"entity"`
 	EntityID  string    `json:"entity_id"`
 	Timestamp time.Time `json:"timestamp"`
+	Metadata  Metadata  `json:"metadata,omitempty"`
+}
+
+// Metadata holds optional before/after state for mutations.
+type Metadata struct {
+	Before json.RawMessage `json:"before,omitempty"`
+	After  json.RawMessage `json:"after,omitempty"`
 }
 
 type ListParams struct {

--- a/internal/domain/audit/service_pg.go
+++ b/internal/domain/audit/service_pg.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 )
 
@@ -12,16 +13,22 @@ func NewPostgresService(db *sql.DB) Service { return &pgService{db: db} }
 
 func (s *pgService) Record(e Event) error {
 	const q = `
-INSERT INTO audit_logs (org_id, actor_id, action, entity, entity_id, created_at)
-VALUES ($1,$2,$3,$4,$5,$6)`
-	_, err := s.db.ExecContext(context.Background(), q,
-		e.OrgID, e.ActorID, e.Action, e.Entity, e.EntityID, time.Now())
+INSERT INTO audit_logs (org_id, actor_id, action, entity, entity_id, metadata, created_at)
+VALUES ($1,$2,$3,$4,$5,$6,$7)`
+
+	meta, err := json.Marshal(e.Metadata)
+	if err != nil {
+		meta = []byte("{}")
+	}
+
+	_, err = s.db.ExecContext(context.Background(), q,
+		e.OrgID, e.ActorID, e.Action, e.Entity, e.EntityID, meta, time.Now())
 	return err
 }
 
 func (s *pgService) List(p ListParams) ([]Event, error) {
 	const q = `
-SELECT org_id, actor_id, action, entity, entity_id, created_at
+SELECT org_id, actor_id, action, entity, entity_id, COALESCE(metadata, '{}'), created_at
 FROM audit_logs
 WHERE org_id = $1
   AND ($2::text IS NULL OR actor_id = $2)
@@ -31,7 +38,7 @@ WHERE org_id = $1
   AND ($6::timestamptz IS NULL OR created_at <= $6)
 ORDER BY created_at DESC
 LIMIT $7 OFFSET $8`
-	// sane defaults
+
 	limit := p.Limit
 	if limit <= 0 || limit > 100 {
 		limit = 20
@@ -51,8 +58,12 @@ LIMIT $7 OFFSET $8`
 	var out []Event
 	for rows.Next() {
 		var e Event
-		if err := rows.Scan(&e.OrgID, &e.ActorID, &e.Action, &e.Entity, &e.EntityID, &e.Timestamp); err != nil {
+		var metaBytes []byte
+		if err := rows.Scan(&e.OrgID, &e.ActorID, &e.Action, &e.Entity, &e.EntityID, &metaBytes, &e.Timestamp); err != nil {
 			return nil, err
+		}
+		if len(metaBytes) > 0 {
+			_ = json.Unmarshal(metaBytes, &e.Metadata)
 		}
 		out = append(out, e)
 	}

--- a/internal/http/handlers/orgs.go
+++ b/internal/http/handlers/orgs.go
@@ -1,19 +1,25 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Ulpio/vergo/internal/domain/audit"
 	"github.com/Ulpio/vergo/internal/domain/org"
 	"github.com/Ulpio/vergo/internal/http/middleware"
 )
 
 type OrgsHandler struct {
 	os org.Service
+	as audit.Service
 }
 
-func NewOrgsHandler(os org.Service) *OrgsHandler { return &OrgsHandler{os: os} }
+func NewOrgsHandler(os org.Service, as audit.Service) *OrgsHandler {
+	return &OrgsHandler{os: os, as: as}
+}
 
 type createOrgIn struct {
 	Name string `json:"name" binding:"required"`
@@ -35,6 +41,14 @@ func (h *OrgsHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_failed"})
 		return
 	}
+
+	after, _ := json.Marshal(o)
+	_ = h.as.Record(audit.Event{
+		OrgID: o.ID, ActorID: uid, Action: "org.created",
+		Entity: "org", EntityID: o.ID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{After: after},
+	})
+
 	c.JSON(http.StatusCreated, o)
 }
 
@@ -55,6 +69,7 @@ type memberIn struct {
 
 func (h *OrgsHandler) AddMember(c *gin.Context) {
 	orgID := c.Param("id")
+	actorID, _ := middleware.UserID(c)
 	var in memberIn
 	if err := c.ShouldBindJSON(&in); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_payload"})
@@ -64,12 +79,21 @@ func (h *OrgsHandler) AddMember(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "add_failed"})
 		return
 	}
+
+	after, _ := json.Marshal(gin.H{"user_id": in.UserID, "role": in.Role})
+	_ = h.as.Record(audit.Event{
+		OrgID: orgID, ActorID: actorID, Action: "member.added",
+		Entity: "membership", EntityID: in.UserID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{After: after},
+	})
+
 	c.Status(http.StatusNoContent)
 }
 
 func (h *OrgsHandler) UpdateMember(c *gin.Context) {
 	orgID := c.Param("id")
 	userID := c.Param("userID")
+	actorID, _ := middleware.UserID(c)
 	var in struct {
 		Role string `json:"role" binding:"required"`
 	}
@@ -78,28 +102,55 @@ func (h *OrgsHandler) UpdateMember(c *gin.Context) {
 		return
 	}
 	if err := h.os.UpdateMember(orgID, userID, in.Role); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "updated_failed", "detai": err.Error()})
+		c.JSON(http.StatusNotFound, gin.H{"error": "updated_failed", "detail": err.Error()})
 		return
 	}
+
+	after, _ := json.Marshal(gin.H{"user_id": userID, "role": in.Role})
+	_ = h.as.Record(audit.Event{
+		OrgID: orgID, ActorID: actorID, Action: "member.updated",
+		Entity: "membership", EntityID: userID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{After: after},
+	})
+
 	c.Status(http.StatusNoContent)
 }
 
 func (h *OrgsHandler) RemoveMember(c *gin.Context) {
 	orgID := c.Param("id")
 	userID := c.Param("userID")
+	actorID, _ := middleware.UserID(c)
 
 	if err := h.os.RemoveMember(orgID, userID); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "failed_remove_member", "detail": err.Error()})
 		return
 	}
+
+	before, _ := json.Marshal(gin.H{"user_id": userID})
+	_ = h.as.Record(audit.Event{
+		OrgID: orgID, ActorID: actorID, Action: "member.removed",
+		Entity: "membership", EntityID: userID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{Before: before},
+	})
+
 	c.Status(http.StatusNoContent)
 }
 
 func (h *OrgsHandler) Delete(c *gin.Context) {
 	orgID := c.Param("id")
+	actorID, _ := middleware.UserID(c)
+
 	if err := h.os.Delete(orgID); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "failed_delete_organization", "detail": err.Error()})
 		return
 	}
+
+	before, _ := json.Marshal(gin.H{"org_id": orgID})
+	_ = h.as.Record(audit.Event{
+		OrgID: orgID, ActorID: actorID, Action: "org.deleted",
+		Entity: "org", EntityID: orgID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{Before: before},
+	})
+
 	c.Status(http.StatusNoContent)
 }

--- a/internal/http/handlers/projects.go
+++ b/internal/http/handlers/projects.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -59,13 +60,11 @@ func (h *ProjectsHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_fail", "detail": err.Error()})
 		return
 	}
+	after, _ := json.Marshal(p)
 	_ = h.as.Record(audit.Event{
-		OrgID:     orgID,
-		ActorID:   userID,
-		Action:    "project.created",
-		Entity:    "project",
-		EntityID:  p.ID,
-		Timestamp: time.Now(),
+		OrgID: orgID, ActorID: userID, Action: "project.created",
+		Entity: "project", EntityID: p.ID, Timestamp: time.Now(),
+		Metadata: audit.Metadata{After: after},
 	})
 	c.JSON(http.StatusCreated, p)
 }
@@ -91,7 +90,13 @@ func (h *ProjectsHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing_org_id"})
 		return
 	}
+	userID, _ := middleware.UserID(c)
 	id := c.Param("id")
+
+	// Capture before state
+	old, _ := h.ps.Get(orgID, id)
+	before, _ := json.Marshal(old)
+
 	var in ProjectIn
 	if err := c.ShouldBindJSON(&in); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_payload"})
@@ -102,6 +107,14 @@ func (h *ProjectsHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "not_found", "detail": err.Error()})
 		return
 	}
+
+	after, _ := json.Marshal(p)
+	_ = h.as.Record(audit.Event{
+		OrgID: orgID, ActorID: userID, Action: "project.updated",
+		Entity: "project", EntityID: id, Timestamp: time.Now(),
+		Metadata: audit.Metadata{Before: before, After: after},
+	})
+
 	c.JSON(http.StatusOK, p)
 }
 
@@ -111,19 +124,22 @@ func (h *ProjectsHandler) Delete(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing_org_id"})
 		return
 	}
-	userID, _ := middleware.UserID(c) // só pra auditoria
+	userID, _ := middleware.UserID(c)
 	id := c.Param("id")
+
+	// Capture before state
+	old, _ := h.ps.Get(orgID, id)
+	before, _ := json.Marshal(old)
+
 	if err := h.ps.Delete(orgID, id); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 		return
 	}
+
 	_ = h.as.Record(audit.Event{
-		OrgID:     orgID,
-		ActorID:   userID,
-		Action:    "project.deleted",
-		Entity:    "project",
-		EntityID:  id,
-		Timestamp: time.Now(),
+		OrgID: orgID, ActorID: userID, Action: "project.deleted",
+		Entity: "project", EntityID: id, Timestamp: time.Now(),
+		Metadata: audit.Metadata{Before: before},
 	})
 	c.Status(http.StatusNoContent)
 }

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -40,7 +40,7 @@ func Register(v1 *gin.RouterGroup) {
 
 	// Handler
 	authH := handlers.NewAuthHandler(cfg, userSvc, rfStore)
-	orgH := handlers.NewOrgsHandler(orgSvc)
+	orgH := handlers.NewOrgsHandler(orgSvc, auditSvc)
 	projH := handlers.NewProjectsHandler(projSvc, auditSvc)
 	meH := handlers.NewMeHandler(userSvc, orgSvc)
 	auditH := handlers.NewAuditHandler(auditSvc)

--- a/internal/pkg/db/migrations/0007_audit_metadata.up.sql
+++ b/internal/pkg/db/migrations/0007_audit_metadata.up.sql
@@ -1,0 +1,5 @@
+-- Add metadata column for before/after diff tracking
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}';
+
+-- Index for querying metadata fields
+CREATE INDEX IF NOT EXISTS idx_audit_metadata ON audit_logs USING gin(metadata);


### PR DESCRIPTION
## Summary
- Add JSONB `metadata` column to `audit_logs` for before/after state tracking
- Expand audit recording to orgs and membership handlers (previously only projects)
- Capture before state on updates/deletes, after state on creates

## O que foi feito
- Migration `0007_audit_metadata.up.sql`: add `metadata JSONB` column with GIN index
- `audit.Metadata` struct with `Before`/`After` as `json.RawMessage`
- `service_pg.go`: serialize/deserialize metadata in Record/List
- `orgs.go`: audit `org.created`, `org.deleted`, `member.added`, `member.updated`, `member.removed`
- `projects.go`: add before/after diff to `project.created`, `project.updated`, `project.deleted`
- `router.go`: inject `auditSvc` into `NewOrgsHandler`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Manual: create/update/delete project → query `GET /audit` → verify metadata field

Closes #40