### PR TITLE
feat(security): fuzz tests for JWT/RBAC + fix auth panic

### DIFF
--- a/internal/auth/jwt_fuzz_test.go
+++ b/internal/auth/jwt_fuzz_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"testing"
+)
+
+// FuzzParse feeds arbitrary strings into auth.Parse to ensure it never panics
+// and always returns a clean error for invalid input.
+func FuzzParse(f *testing.F) {
+	// Seed corpus: valid-looking tokens, partial tokens, edge cases
+	f.Add("", "secret")
+	f.Add("not.a.token", "secret")
+	f.Add("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIxMjMiLCJ0eXAiOiJhY2Nlc3MifQ.invalid", "secret")
+	f.Add("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJ1aWQiOiIxMjMifQ.", "secret")
+	f.Add("....", "secret")
+	f.Add("a]]]", "")
+	f.Add("\x00\xff\xfe", "secret")
+
+	f.Fuzz(func(t *testing.T, tokenStr, secret string) {
+		// Must never panic regardless of input
+		claims, err := Parse(tokenStr, secret)
+		if err == nil && claims == nil {
+			t.Error("Parse returned nil error and nil claims")
+		}
+	})
+}
+
+// FuzzNewAccessToken feeds arbitrary user IDs and secrets to ensure token
+// generation never panics.
+func FuzzNewAccessToken(f *testing.F) {
+	f.Add("user-123", "my-secret", 15)
+	f.Add("", "", 0)
+	f.Add("\x00\xff", "s", 1)
+	f.Add("a]]]{}\"", "secret-with-special!@#$", 525600)
+
+	f.Fuzz(func(t *testing.T, userID, secret string, ttl int) {
+		if ttl < 0 || ttl > 525600 {
+			t.Skip()
+		}
+		token, err := NewAccessToken(userID, secret, ttl)
+		if err != nil {
+			return // signing errors are acceptable
+		}
+		if token == "" {
+			t.Error("NewAccessToken returned empty token without error")
+		}
+	})
+}
+
+// FuzzRoundTrip generates a token and parses it back, verifying that valid
+// tokens always round-trip correctly.
+func FuzzRoundTrip(f *testing.F) {
+	f.Add("user-abc", "test-secret", 15)
+	f.Add("", "s", 1)
+	f.Add("uid-with-special/chars", "long-secret-key-for-hmac-256", 60)
+
+	f.Fuzz(func(t *testing.T, userID, secret string, ttl int) {
+		if ttl <= 0 || ttl > 525600 || secret == "" {
+			t.Skip()
+		}
+		token, err := NewAccessToken(userID, secret, ttl)
+		if err != nil {
+			t.Fatalf("NewAccessToken failed: %v", err)
+		}
+		claims, err := Parse(token, secret)
+		if err != nil {
+			t.Fatalf("Parse failed on valid token: %v", err)
+		}
+		if claims.UserID != userID {
+			t.Errorf("UserID mismatch: got %q, want %q", claims.UserID, userID)
+		}
+		if claims.TokenType != "access" {
+			t.Errorf("TokenType mismatch: got %q, want %q", claims.TokenType, "access")
+		}
+	})
+}
+
+// FuzzParseWrongSecret verifies that parsing a valid token with the wrong
+// secret always fails.
+func FuzzParseWrongSecret(f *testing.F) {
+	f.Add("user-1", "correct-secret", "wrong-secret")
+
+	f.Fuzz(func(t *testing.T, userID, signSecret, parseSecret string) {
+		if signSecret == parseSecret || signSecret == "" {
+			t.Skip()
+		}
+		token, err := NewAccessToken(userID, signSecret, 15)
+		if err != nil {
+			t.Skip()
+		}
+		_, err = Parse(token, parseSecret)
+		if err == nil {
+			t.Error("Parse should fail with wrong secret")
+		}
+	})
+}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -12,13 +12,18 @@ import (
 const ctxUserID = "user_id"
 
 func Auth(cfg config.Config) gin.HandlerFunc {
+	const prefix = "bearer "
 	return func(c *gin.Context) {
 		h := c.GetHeader("Authorization")
-		if h == "" || strings.HasPrefix(strings.ToLower(h), "Bearer") {
+		if !strings.HasPrefix(strings.ToLower(h), prefix) {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing_bearer"})
 			return
 		}
-		token := strings.TrimSpace(h[len("Bearer "):])
+		token := strings.TrimSpace(h[len(prefix):])
+		if token == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing_bearer"})
+			return
+		}
 		claims, err := auth.Parse(token, cfg.JWTAccessSecret)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})

--- a/internal/http/middleware/auth_fuzz_test.go
+++ b/internal/http/middleware/auth_fuzz_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Ulpio/vergo/internal/pkg/config"
+	"github.com/gin-gonic/gin"
+)
+
+// FuzzAuthHeader feeds arbitrary Authorization header values into the Auth
+// middleware to ensure it never panics and always returns a safe HTTP status.
+func FuzzAuthHeader(f *testing.F) {
+	// Seed corpus: common patterns and edge cases
+	f.Add("")
+	f.Add("Bearer ")
+	f.Add("Bearer valid-looking-token")
+	f.Add("bearer lowercase")
+	f.Add("Basic dXNlcjpwYXNz")
+	f.Add("BearerNoSpace")
+	f.Add("Bearer\t\ttabs")
+	f.Add("\x00\xff\xfe")
+	f.Add("Bearer " + string(make([]byte, 10000)))
+
+	f.Fuzz(func(t *testing.T, header string) {
+		w := httptest.NewRecorder()
+		_, r := gin.CreateTestContext(w)
+
+		cfg := config.Config{JWTAccessSecret: "fuzz-secret"}
+		r.GET("/test", Auth(cfg), func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+		r.ServeHTTP(w, req)
+
+		// Must be a valid HTTP status, never panic
+		status := w.Code
+		if status < 200 || status >= 600 {
+			t.Errorf("invalid status code: %d", status)
+		}
+	})
+}

--- a/internal/http/middleware/rbac_fuzz_test.go
+++ b/internal/http/middleware/rbac_fuzz_test.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// FuzzRequireRole feeds arbitrary role strings into the RBAC middleware to
+// ensure it never panics and always enforces access control correctly.
+func FuzzRequireRole(f *testing.F) {
+	// Seed: valid roles, empty, unknown roles, special chars
+	f.Add("owner", "owner")
+	f.Add("admin", "member")
+	f.Add("member", "admin")
+	f.Add("", "")
+	f.Add("superadmin", "owner")
+	f.Add("\x00", "member")
+	f.Add("owner", "\xff\xfe")
+	f.Add("OWNER", "owner")
+
+	f.Fuzz(func(t *testing.T, minRole, actualRole string) {
+		w := httptest.NewRecorder()
+		c, r := gin.CreateTestContext(w)
+
+		// Register handler with RBAC middleware
+		r.GET("/test", func(c *gin.Context) {
+			c.Set(ctxRole, actualRole)
+			c.Next()
+		}, RequireRole(minRole), func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+		r.ServeHTTP(w, c.Request)
+
+		// Must always return a valid HTTP status (never panic)
+		status := w.Code
+		if status != http.StatusOK && status != http.StatusForbidden {
+			t.Errorf("unexpected status %d for minRole=%q actualRole=%q", status, minRole, actualRole)
+		}
+
+		// Known valid roles: verify correctness
+		minLevel := roleOrder[minRole]
+		actualLevel := roleOrder[actualRole]
+		if minLevel > 0 && actualLevel > 0 {
+			if actualLevel >= minLevel && status != http.StatusOK {
+				t.Errorf("should allow: actualRole=%q (level %d) >= minRole=%q (level %d), got %d",
+					actualRole, actualLevel, minRole, minLevel, status)
+			}
+			if actualLevel < minLevel && status != http.StatusForbidden {
+				t.Errorf("should deny: actualRole=%q (level %d) < minRole=%q (level %d), got %d",
+					actualRole, actualLevel, minRole, minLevel, status)
+			}
+		}
+	})
+}
+
+// FuzzRoleOrder verifies that unknown roles always get level 0 (no access)
+// and known roles maintain their expected hierarchy.
+func FuzzRoleOrder(f *testing.F) {
+	f.Add("member")
+	f.Add("admin")
+	f.Add("owner")
+	f.Add("")
+	f.Add("root")
+	f.Add("ADMIN")
+
+	f.Fuzz(func(t *testing.T, role string) {
+		level := roleOrder[role]
+		switch role {
+		case "member":
+			if level != 1 {
+				t.Errorf("member should be level 1, got %d", level)
+			}
+		case "admin":
+			if level != 2 {
+				t.Errorf("admin should be level 2, got %d", level)
+			}
+		case "owner":
+			if level != 3 {
+				t.Errorf("owner should be level 3, got %d", level)
+			}
+		default:
+			if level != 0 {
+				t.Errorf("unknown role %q should be level 0, got %d", role, level)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add 7 fuzz tests covering JWT parsing, token generation, RBAC role hierarchy, and auth header handling
- **Fix panic bug** in auth middleware: malformed `Authorization` headers shorter than 7 chars caused `slice bounds out of range` crash
- Auth middleware had inverted logic (`HasPrefix` with mixed-case "Bearer" after `ToLower`)

## Bug encontrado pelo fuzzer
O middleware `Auth` fazia `h[len("Bearer "):]` sem verificar o comprimento do header. Inputs como `\x00\xff\xfe` causavam panic por `slice bounds out of range`. Além disso, a lógica de verificação estava invertida — rejeitava headers que *tinham* o prefixo Bearer.

## Fuzz tests adicionados

| Test | Pacote | Alvo |
|------|--------|------|
| `FuzzParse` | `internal/auth` | JWT parsing com tokens malformados |
| `FuzzNewAccessToken` | `internal/auth` | Geração de tokens com inputs arbitrários |
| `FuzzRoundTrip` | `internal/auth` | Gerar → parsear deve sempre funcionar |
| `FuzzParseWrongSecret` | `internal/auth` | Secret errado deve sempre falhar |
| `FuzzRequireRole` | `internal/http/middleware` | RBAC com roles arbitrárias |
| `FuzzRoleOrder` | `internal/http/middleware` | Hierarquia de roles |
| `FuzzAuthHeader` | `internal/http/middleware` | Headers Authorization malformados |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (64 tests)
- [x] `go vet ./...` clean
- [x] `go test -fuzz=FuzzParse -fuzztime=5s` — no crashes
- [x] `go test -fuzz=FuzzRequireRole -fuzztime=5s` — no crashes
- [x] `go test -fuzz=FuzzAuthHeader -fuzztime=5s` — no crashes

Closes #32