### PR TITLE
feat: Dev Container for VS Code / Cursor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/go:1-1.25-bookworm
+
+# Go tools used by the project
+RUN go install github.com/air-verse/air@latest \
+ && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+ && go install github.com/swaggo/swag/cmd/swag@latest \
+ && go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+# Python + sqlfluff (for SQL lint)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3-pip \
+ && pip3 install --break-system-packages sqlfluff \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+{
+  "name": "Vergo",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.25"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "mtxr.sqltools",
+        "mtxr.sqltools-driver-pg",
+        "eamodio.gitlens",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "go.useLanguageServer": true,
+        "go.lintTool": "golangci-lint",
+        "go.lintFlags": ["--fast"],
+        "editor.formatOnSave": true,
+        "[go]": {
+          "editor.defaultFormatter": "golang.go"
+        }
+      }
+    }
+  },
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "forwardPorts": [8080, 5432, 16686, 9090, 9091],
+  "portsAttributes": {
+    "8080": { "label": "Vergo API" },
+    "5432": { "label": "PostgreSQL" },
+    "16686": { "label": "Jaeger UI" },
+    "9090": { "label": "Prometheus" },
+    "9091": { "label": "Metrics" }
+  },
+
+  "remoteEnv": {
+    "DB_HOST": "db",
+    "DB_PORT": "5432",
+    "DB_USER": "app",
+    "DB_PASSWORD": "app",
+    "DB_NAME": "vergo",
+    "DB_SSLMODE": "disable",
+    "APP_ENV": "development"
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: vergo
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d vergo"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing Go dependencies..."
+go mod download
+
+echo "==> Running database migrations..."
+migrate -path ./db/migrations \
+  -database "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=${DB_SSLMODE}" \
+  up || true
+
+echo "==> Generating Swagger docs..."
+swag init -g cmd/api/main.go -o docs/swagger --parseDependency --parseInternal 2>/dev/null || true
+
+echo "==> Dev container ready!"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Para subir Postgres + PgAdmin:
 docker compose up -d db pgadmin
 ```
 
+### Dev Container (VS Code / Cursor)
+
+Open the project in a ready-to-code environment with Go, PostgreSQL, and all tools pre-installed:
+
+1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+2. Open the project folder → **Ctrl+Shift+P** → *"Dev Containers: Reopen in Container"*
+3. Wait for the container to build (first time only, ~2 min)
+
+The container includes: Go 1.25, PostgreSQL 16, `migrate`, `golangci-lint`, `swag`, `air`, `sqlfluff`.
+Ports forwarded: API (8080), PostgreSQL (5432), Jaeger (16686), Prometheus (9090).
+
 ---
 
 ## 🧱 Estrutura do projeto


### PR DESCRIPTION
## Summary

- `.devcontainer/` with Go 1.25, PostgreSQL 16, and all project tools pre-installed
- Tools included: `migrate`, `golangci-lint`, `swag`, `air`, `sqlfluff`
- Post-create script runs `go mod download`, migrations, and swagger generation
- Ports forwarded: API (8080), PostgreSQL (5432), Jaeger (16686), Prometheus (9090)
- README updated with "Open in Dev Container" instructions

## Files

- `.devcontainer/devcontainer.json` — VS Code config, extensions, settings, port forwarding
- `.devcontainer/docker-compose.yml` — app + postgres services
- `.devcontainer/Dockerfile` — Go devcontainer image with project tools
- `.devcontainer/post-create.sh` — auto-setup on container creation
- `README.md` — added Dev Container section

## Test plan

- [ ] VS Code: "Reopen in Container" builds successfully
- [ ] `go build ./...` works inside container
- [ ] `make test` passes inside container
- [ ] PostgreSQL accessible at `db:5432`
- [ ] Migrations run automatically on creation

Closes #37